### PR TITLE
Add agenda, unconference details, and call for contributions

### DIFF
--- a/ossna-25/README.md
+++ b/ossna-25/README.md
@@ -1,1 +1,22 @@
 Welcome to the shared repo for FLOSS-Mentoring activities at Open Source Summit North America 2025!
+
+Attend our session:
+
+>**FLOSS Mentorship Unconference: A Community Event to Share, Shape, & Scale Mentoring Efforts in Open Source**  
+>📅 Tuesday June 24, 2025 2:10pm - 5:00pm MDT  
+>📍 Bluebird Ballroom 3D  
+>🔗[Sched event](https://ossna2025.sched.com/event/23YvJ/floss-mentorship-unconference-a-community-event-to-share-shape-scale-mentoring-efforts-in-open-source-open-to-all-attendees-no-pre-registration-required)
+
+
+Our agenda is flexible, as a starting point we have prepared the following discussion topics:
+
+- Addressing and preparing for incidents of mentor misconduct
+- Developments in mentor training and recruitment strategies
+- When mentees are working as part of a team, what can be done to prevent one student from doing all the work?
+- How should mentorship programs address student overuse of AI tools?
+- Helping first-time contributors build trust and rapport with maintainers
+- Supporting inclusive engagement across languages and timezones
+
+📝 Throughout your discussions, we encourage you to take notes and submit them as a pull request to this repository.
+
+Contributions sharing your experiences in FLOSS mentoring are also welcome! Consider sharing details of your mentorship program, solutions you have implemented, or problems you are facing in need of a solution.


### PR DESCRIPTION
I reworded the agenda we discussed in Discord to be more external friendly.

I know we talked about providing times, do we want to commit to that or leave things more open to encourage conversations to wander as they like?